### PR TITLE
Increasing sweep interval to 24 hours

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 gcd_sock_volume: /var/run/docker.sock
 gcd_docker_host: unix:///var/run/docker.sock
-gcd_sweep_interval: 1
+gcd_sweep_interval: 86400
 gcd_remove_images: true
 gcd_remove_healthy_containers_exited: true


### PR DESCRIPTION
1 second was so fast that it broke tsuru deploys. The main problem
is running the sweep while the deploy is happening. While increasing
the interval does not fully solve the problem, it decrease it's probability
to something acceptable until it become a priority again.